### PR TITLE
bug fix when update row twice

### DIFF
--- a/lib/DBIx/Skinny/Row.pm
+++ b/lib/DBIx/Skinny/Row.pm
@@ -96,7 +96,7 @@ sub set {
 sub get_dirty_columns {
     my $self = shift;
 
-    my %rows = map {$_ => $self->get_column($_)}
+    my %rows = map {$_ => $self->{_get_column_cached}->{$_}}
                keys %{$self->{_dirty_columns}};
 
     return \%rows;

--- a/lib/DBIx/Skinny/Row.pm
+++ b/lib/DBIx/Skinny/Row.pm
@@ -117,6 +117,7 @@ sub update {
 
     my $result = $self->{skinny}->update($table, $upd, $self->_where_cond($table));
     $self->set_columns($upd);
+    $self->{_dirty_columns} = {};
 
     return $result;
 }

--- a/t/999_regression/deflate_bug.t
+++ b/t/999_regression/deflate_bug.t
@@ -20,4 +20,20 @@ subtest 'scalar data bug case' => sub {
     is $row->name->name, 'azumakuniyuki_deflate';
 };
 
+subtest 'update row twice case' => sub {
+    my $row = Mock::Inflate->single('mock_inflate',{id => 1});
+    my $name = $row->name;
+    $name->name('perl');
+    $row->update({ name => $name });
+    isa_ok $row->name, 'Mock::Inflate::Name';
+    is $row->name->name, 'perl';
+
+    # twice update!
+    $row->update({id => 1});
+
+    # if name is row_data then incorrect
+    isa_ok $row->name, 'Mock::Inflate::Name';
+    is $row->name->name, 'perl';
+};
+
 done_testing;

--- a/t/999_regression/duplicate_update.t
+++ b/t/999_regression/duplicate_update.t
@@ -1,0 +1,34 @@
+use t::Utils;
+use Mock::Basic;
+use Test::More;
+
+my $dbh = t::Utils->setup_dbh;
+Mock::Basic->set_dbh($dbh);
+Mock::Basic->setup_test_db;
+
+Mock::Basic->insert('mock_basic',{
+    id   => 1,
+    name => 'perl',
+});
+
+use DBIx::Skinny::Profiler;
+Mock::Basic->_attributes->{profiler} = DBIx::Skinny::Profiler->new;
+
+subtest 'duplicate_update' => sub {
+    my $row = Mock::Basic->single('mock_basic',{
+        id => 1,
+    });
+    Mock::Basic->profiler->reset;
+    $row->update({
+        name => 'ruby',
+    });
+    is +Mock::Basic->profiler->query_log->[0] , 'UPDATE mock_basic SET `name` = ? WHERE (id = ?) :binds ruby, 1';
+    Mock::Basic->profiler->reset;
+    $row->update({
+        id => 1,
+    });
+    is +Mock::Basic->profiler->query_log->[0] , 'UPDATE mock_basic SET `id` = ? WHERE (id = ?) :binds 1, 1';
+    Mock::Basic->profiler->reset;
+};
+
+done_testing;

--- a/t/999_regression/duplicate_update.t
+++ b/t/999_regression/duplicate_update.t
@@ -11,24 +11,32 @@ Mock::Basic->insert('mock_basic',{
     name => 'perl',
 });
 
-use DBIx::Skinny::Profiler;
-Mock::Basic->_attributes->{profiler} = DBIx::Skinny::Profiler->new;
-
 subtest 'duplicate_update' => sub {
     my $row = Mock::Basic->single('mock_basic',{
         id => 1,
     });
-    Mock::Basic->profiler->reset;
+    is $row->name => 'perl';
     $row->update({
         name => 'ruby',
     });
-    is +Mock::Basic->profiler->query_log->[0] , 'UPDATE mock_basic SET `name` = ? WHERE (id = ?) :binds ruby, 1';
-    Mock::Basic->profiler->reset;
+
+    my $row2 = Mock::Basic->single('mock_basic',{
+        id => 1,
+    });
+    is $row2->name => 'ruby';
+    $row2->update({
+        name => 'python'
+    });
+    is $row2->name => 'python';
+
+    # please dont update `name`!
     $row->update({
         id => 1,
     });
-    is +Mock::Basic->profiler->query_log->[0] , 'UPDATE mock_basic SET `id` = ? WHERE (id = ?) :binds 1, 1';
-    Mock::Basic->profiler->reset;
+
+    is +Mock::Basic->single('mock_basic',{
+        id => 1,
+    })->name => 'python';
 };
 
 done_testing;


### PR DESCRIPTION
1. update inflated row twice bug 
2. avoid duplicate update field 

japanese)
1. inflateなcolumnをupdateした後にそのcolumnを含まないupdateをすると$row->columnがrow_dataになっちゃてるバグの修正
2. updateの時に_dirty_columnをクリアしてないのでupdateが複数走ると毎度同じ以前のカラムをupdateしにいってますー。普通は問題ないと思うのですがトランザクションが絡んでると問題になる場合もあるんじゃないかと。
