### PR TITLE
Call txn scope after missing connect

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,7 +19,7 @@ test_requires 'Test::SharedFork' => 0.15;
 test_requires 'Test::mysqld'     if $Module::Install::AUTHOR;
 test_requires 'Test::postgresql' if $Module::Install::AUTHOR;
 
-tests 't/*.t t/*/*.t';
+tests 't/*.t t/*/*.t t/*/*/*.t';
 
 auto_set_repository;
 WriteAll;

--- a/lib/DBIx/Skinny.pm
+++ b/lib/DBIx/Skinny.pm
@@ -146,15 +146,8 @@ sub suppress_row_objects {
 sub txn_manager  {
     my $class = shift;
 
-    $class->_verify_pid;
-
-    $class->_attributes->{txn_manager} ||= do {
-        my $dbh = $class->dbh;
-        unless ($dbh) {
-            Carp::croak("dbh is not found.");
-        }
-        DBIx::TransactionManager->new($dbh);
-    };
+    my $dbh = $class->dbh;
+    $class->_attributes->{txn_manager} ||= DBIx::TransactionManager->new($dbh);
 }
 
 sub in_transaction_check {

--- a/t/999_regression/transaction/call_txn_scope_after_missing_connect.t
+++ b/t/999_regression/transaction/call_txn_scope_after_missing_connect.t
@@ -1,0 +1,44 @@
+use t::Utils;
+use Mock::Basic;
+use Test::More;
+
+my $db = './test.db';
+
+unlink $db;
+Mock::Basic->connect_info(+{
+    dsn      => "dbi:SQLite:$db",
+    username => '',
+    password => '',
+});
+Mock::Basic->setup_test_db;
+
+    {
+        {
+            my $txn = Mock::Basic->txn_scope;
+                my $row = Mock::Basic->insert('mock_basic',{
+                    id   => 2,
+                    name => 'ruby',
+                });
+                isa_ok $row, 'DBIx::Skinny::Row';
+                is $row->name, 'ruby';
+            $txn->commit;
+        }
+
+        Mock::Basic->dbh->disconnect; # missing connect
+
+        {
+            my $txn = Mock::Basic->txn_scope;
+                my $row = Mock::Basic->single('mock_basic',{name => 'ruby'});
+                is $row->id, 2;
+                $row = Mock::Basic->insert('mock_basic',{
+                    id   => 3,
+                    name => 'perl',
+                });
+                isa_ok $row, 'DBIx::Skinny::Row';
+                is $row->name, 'perl';
+            $txn->commit;
+        }
+    }
+
+unlink $db;
+done_testing;


### PR DESCRIPTION
connectが失われていてreconnectが発生する状況下で
dbhの前にtxn_managerが呼ばれると以前のtxn_managerを使ってしまうです。
txn_managerでも先にdbhをとっておくととりあえず解決なのかなと。
DBIx::Handlerと同じ対処ですね。
