### PR TITLE
Update PID when we connect to DB

### DIFF
--- a/lib/DBIx/Skinny.pm
+++ b/lib/DBIx/Skinny.pm
@@ -200,6 +200,7 @@ sub connect {
     my $attr = $class->_attributes;
     my $do_connected=0;
     if ( !$attr->{dbh} ) {
+        $attr->{last_pid} = $$;
         $do_connected=1;
     }
     $attr->{dbh} ||= DBI->connect(

--- a/t/001_basic/005_set_columns.t
+++ b/t/001_basic/005_set_columns.t
@@ -1,16 +1,44 @@
 use t::Utils;
 use Mock::Basic;
+use Test::Builder;
 use Test::More;
 
 my $dbh = t::Utils->setup_dbh;
 Mock::Basic->set_dbh($dbh);
 Mock::Basic->setup_test_db;
 
+sub _normalize_column {
+    my ($cols, $column_list) = @_;
+
+    # shallow copy
+    my @column_list = @$column_list;
+
+    my %hash;
+    for my $k (@$cols) {
+        my $v = $k =~ /\?/ ? shift @column_list : undef;
+        if (exists $hash{$k}) {
+            $hash{$k} = [sort { $a->[0] cmp $b->[1] } (@{$hash{$k}}, $v)];
+        } else {
+            $hash{$k} = [$v];
+        }
+    }
+
+    \%hash;
+}
+
+sub _is_right_column {
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+    my (
+        $result_cols, $expect_cols, $result_column_list, $expect_column_list,
+    ) = @_;
+    is_deeply _normalize_column($result_cols, $result_column_list),
+              _normalize_column($expect_cols, $expect_column_list);
+}
+
 subtest 'insert mode' => sub {
     my ($cols, $column_list) = Mock::Basic->_set_columns(+{id => 1, name => 'nekokak'}, 1);
 
-    is_deeply $cols, +['?','?'];
-    is_deeply $column_list, [
+    _is_right_column $cols, +['?','?'], $column_list, [
         [
             'name',
             'nekokak',
@@ -26,11 +54,10 @@ subtest 'insert mode' => sub {
 subtest 'insert mode / scalarref' => sub {
     my ($cols, $column_list) = Mock::Basic->_set_columns(+{id => 1, name => \'NOW ()'}, 1);
 
-    is_deeply $cols, +[
+    _is_right_column $cols, +[
         'NOW ()',
         '?',
-    ];
-    is_deeply $column_list, [
+    ], $column_list, [
         [
             'id',
             1,
@@ -42,11 +69,10 @@ subtest 'insert mode / scalarref' => sub {
 subtest 'update mode' => sub {
     my ($cols, $column_list) = Mock::Basic->_set_columns(+{id => 1, name => 'nekokak'}, 0);
 
-    is_deeply $cols, +[
+    _is_right_column $cols, +[
         '`name` = ?',
         '`id` = ?',
-    ];
-    is_deeply $column_list, [
+    ], $column_list, [
         [
             'name',
             'nekokak',
@@ -62,11 +88,10 @@ subtest 'update mode' => sub {
 subtest 'update mode / scalarref' => sub {
     my ($cols, $column_list) = Mock::Basic->_set_columns(+{id => 1, name => \'NOW()'}, 0);
 
-    is_deeply $cols, +[
+    _is_right_column $cols, +[
         '`name` = NOW()',
         '`id` = ?',
-    ];
-    is_deeply $column_list, [
+    ], $column_list, [
         [
             'id',
             1,

--- a/t/001_basic/019_profiler_trace.t
+++ b/t/001_basic/019_profiler_trace.t
@@ -20,7 +20,8 @@ Mock::Basic->insert('mock_basic',{
     id   => 1,
     name => 'perl',
 });
-is $content, qq{CREATE TABLE mock_basic ( id integer, name text, delete_fg int(1) default 0, primary key ( id ) )\nINSERT INTO mock_basic (`name`, `id`) VALUES (?, ?) :binds perl, 1\n};
+ok $content =~ m/CREATE TABLE mock_basic \( id integer, name text, delete_fg int\(1\) default 0, primary key \( id \) \)\nINSERT INTO mock_basic \(`(\w+)`, `(\w+)`\) VALUES \(\?, \?\) :binds (\w+), (\w+)\n/;
+is_deeply {$1 => $3, $2 => $4}, {id => 1, name => 'perl'};
 
 done_testing;
 

--- a/t/002_common/021_quote.t
+++ b/t/002_common/021_quote.t
@@ -14,7 +14,8 @@ subtest 'quote sql by sqlite' => sub {
         id   => 1,
         name => 'perl',
     });
-    is +Mock::Basic->profiler->query_log->[0] , 'INSERT INTO mock_basic (`name`, `id`) VALUES (?, ?) :binds perl, 1';
+    ok +Mock::Basic->profiler->query_log->[0] =~ m/INSERT INTO mock_basic \(`(\w+)`, `(\w+)`\) VALUES \(\?, \?\) :binds (\w+), (\w+)/;
+    is_deeply {$1 => $3, $2 => $4}, {id => 1, name => 'perl'};
     $row->update({name => 'ruby'});
     is +Mock::Basic->profiler->query_log->[1], 'UPDATE mock_basic SET `name` = ? WHERE (id = ?) :binds ruby, 1';
 };

--- a/t/999_regression/fork_and_connect.t
+++ b/t/999_regression/fork_and_connect.t
@@ -1,0 +1,32 @@
+use t::Utils;
+use Mock::Basic;
+use Test::More;
+use Test::SharedFork;
+
+my $db = './test.db';
+
+unlink $db;
+Mock::Basic->connect_info(+{
+    dsn      => "dbi:SQLite:$db",
+    username => '',
+    password => '',
+});
+
+if (fork) {
+    wait;
+    my $dbh1 = Mock::Basic->dbh;
+    my $dbh2 = Mock::Basic->dbh;
+    is $dbh1, $dbh2, 'Reuse connection';
+    ok ! $dbh1->{InactiveDestroy}, "Don't set InactiveDestroy on parent (1)";
+    ok ! $dbh2->{InactiveDestroy}, "Don't set InactiveDestroy on parent (2)";
+    done_testing;
+} else {
+    my $dbh1 = Mock::Basic->dbh;
+    my $dbh2 = Mock::Basic->dbh;
+    is $dbh1, $dbh2, 'Reuse connection';
+    ok ! $dbh1->{InactiveDestroy}, "Don't set InactiveDestroy on child (1)";
+    ok ! $dbh2->{InactiveDestroy}, "Don't set InactiveDestroy on child (2)";
+    exit;
+}
+
+unlink $db;

--- a/t/999_regression/transaction/call_txn_scope_after_fork.t
+++ b/t/999_regression/transaction/call_txn_scope_after_fork.t
@@ -35,6 +35,7 @@ Mock::Basic->setup_test_db;
             is $row->name, 'ruby';
 
         $txn->commit;
+        exit;
     }
 
 unlink $db;

--- a/t/999_regression/transaction/call_txn_scope_and_fork.t
+++ b/t/999_regression/transaction/call_txn_scope_and_fork.t
@@ -29,6 +29,7 @@ Mock::Basic->setup_test_db;
             my $txn = Mock::Basic->txn_scope;
         };
         like $@, qr/Detected transaction while processing forked child \(last known transaction at/;
+        exit;
     }
 
     $txn->commit;

--- a/t/999_regression/transaction/call_txn_scope_before_fork.t
+++ b/t/999_regression/transaction/call_txn_scope_before_fork.t
@@ -41,6 +41,7 @@ Mock::Basic->setup_test_db;
             is $row->name, 'ruby';
 
         $txn->commit;
+        exit;
     }
 
 unlink $db;

--- a/t/999_regression/transaction/call_txn_scope_before_fork_and_rollback.t
+++ b/t/999_regression/transaction/call_txn_scope_before_fork_and_rollback.t
@@ -42,6 +42,7 @@ Mock::Basic->setup_test_db;
             is $row->name, 'ruby';
 
         $txn->rollback;
+        exit;
     }
 
 unlink $db;


### PR DESCRIPTION
If I call Skinny->dbh after fork, the owner of DBI connection and the last_pid field will be contradictory. Then, the next call of _verify_pid will set dbh->{InactiveDestroy} true and this DBI connection won't be disconnected even when it gets undefined. https://github.com/nekokak/p5-dbix-skinny/commit/41aa2fec87113a37c9fe8c7feae58348c4a0fc6b fixes the issue.

I also fix all unit tests to test my patch correctly.
