### PR TITLE
sort keys for randomized hash order

### DIFF
--- a/lib/DBIx/Skinny.pm
+++ b/lib/DBIx/Skinny.pm
@@ -564,7 +564,7 @@ sub _set_columns {
     my $name_sep = $dbd->name_sep;
 
     my (@columns, @bind_columns, @quoted_columns);
-    for my $col (keys %{ $args }) {
+    for my $col (sort keys %{ $args }) {
         my $quoted_col = _quote($col, $quote, $name_sep);
         if (ref($args->{$col}) eq 'SCALAR') {
             push @columns, ($insert ? ${ $args->{$col} } :"$quoted_col = " . ${ $args->{$col} });

--- a/t/001_basic/005_set_columns.t
+++ b/t/001_basic/005_set_columns.t
@@ -12,13 +12,13 @@ subtest 'insert mode' => sub {
     is_deeply $cols, +['?','?'];
     is_deeply $column_list, [
         [
+            'id',
+            1,
+        ],
+        [
             'name',
             'nekokak',
         ],
-        [
-            'id',
-            1,
-        ]
     ];
     done_testing;
 };
@@ -27,8 +27,8 @@ subtest 'insert mode / scalarref' => sub {
     my ($cols, $column_list) = Mock::Basic->_set_columns(+{id => 1, name => \'NOW ()'}, 1);
 
     is_deeply $cols, +[
-        'NOW ()',
         '?',
+        'NOW ()',
     ];
     is_deeply $column_list, [
         [
@@ -43,18 +43,18 @@ subtest 'update mode' => sub {
     my ($cols, $column_list) = Mock::Basic->_set_columns(+{id => 1, name => 'nekokak'}, 0);
 
     is_deeply $cols, +[
-        '`name` = ?',
         '`id` = ?',
+        '`name` = ?',
     ];
     is_deeply $column_list, [
+        [
+            'id',
+            1,
+        ],
         [
             'name',
             'nekokak',
         ],
-        [
-            'id',
-            1,
-        ]
     ];
     done_testing;
 };
@@ -63,8 +63,8 @@ subtest 'update mode / scalarref' => sub {
     my ($cols, $column_list) = Mock::Basic->_set_columns(+{id => 1, name => \'NOW()'}, 0);
 
     is_deeply $cols, +[
-        '`name` = NOW()',
         '`id` = ?',
+        '`name` = NOW()',
     ];
     is_deeply $column_list, [
         [

--- a/t/001_basic/019_profiler_trace.t
+++ b/t/001_basic/019_profiler_trace.t
@@ -20,7 +20,7 @@ Mock::Basic->insert('mock_basic',{
     id   => 1,
     name => 'perl',
 });
-is $content, qq{CREATE TABLE mock_basic ( id integer, name text, delete_fg int(1) default 0, primary key ( id ) )\nINSERT INTO mock_basic (`name`, `id`) VALUES (?, ?) :binds perl, 1\n};
+is $content, qq{CREATE TABLE mock_basic ( id integer, name text, delete_fg int(1) default 0, primary key ( id ) )\nINSERT INTO mock_basic (`id`, `name`) VALUES (?, ?) :binds 1, perl\n};
 
 done_testing;
 

--- a/t/002_common/021_quote.t
+++ b/t/002_common/021_quote.t
@@ -14,7 +14,7 @@ subtest 'quote sql by sqlite' => sub {
         id   => 1,
         name => 'perl',
     });
-    is +Mock::Basic->profiler->query_log->[0] , 'INSERT INTO mock_basic (`name`, `id`) VALUES (?, ?) :binds perl, 1';
+    is +Mock::Basic->profiler->query_log->[0] , 'INSERT INTO mock_basic (`id`, `name`) VALUES (?, ?) :binds 1, perl';
     $row->update({name => 'ruby'});
     is +Mock::Basic->profiler->query_log->[1], 'UPDATE mock_basic SET `name` = ? WHERE (id = ?) :binds ruby, 1';
 };


### PR DESCRIPTION
hash の keys の戻りがランダムになった影響でテストが通らなくなっているので修正です。