### PR TITLE
unlink $db after done_testing.

### DIFF
--- a/t/999_regression/transaction/call_txn_scope_after_fork.t
+++ b/t/999_regression/transaction/call_txn_scope_after_fork.t
@@ -21,6 +21,7 @@ Mock::Basic->setup_test_db;
         is $dbh, +Mock::Basic->dbh;
 
         done_testing;
+        unlink $db;
     } else {
         my $txn = Mock::Basic->txn_scope;
 
@@ -37,5 +38,4 @@ Mock::Basic->setup_test_db;
         $txn->commit;
     }
 
-unlink $db;
 

--- a/t/999_regression/transaction/call_txn_scope_and_fork.t
+++ b/t/999_regression/transaction/call_txn_scope_and_fork.t
@@ -24,6 +24,7 @@ Mock::Basic->setup_test_db;
         is $txn_manager, +Mock::Basic->txn_manager;
 
         done_testing;
+        unlink $db;
     } else {
         eval {
             my $txn = Mock::Basic->txn_scope;
@@ -33,5 +34,4 @@ Mock::Basic->setup_test_db;
 
     $txn->commit;
 
-unlink $db;
 

--- a/t/999_regression/transaction/call_txn_scope_before_fork.t
+++ b/t/999_regression/transaction/call_txn_scope_before_fork.t
@@ -26,6 +26,7 @@ Mock::Basic->setup_test_db;
         is $txn_manager, +Mock::Basic->txn_manager;
 
         done_testing;
+        unlink $db;
     } else {
         my $txn = Mock::Basic->txn_scope;
 
@@ -43,5 +44,4 @@ Mock::Basic->setup_test_db;
         $txn->commit;
     }
 
-unlink $db;
 

--- a/t/999_regression/transaction/call_txn_scope_before_fork_and_rollback.t
+++ b/t/999_regression/transaction/call_txn_scope_before_fork_and_rollback.t
@@ -27,6 +27,7 @@ Mock::Basic->setup_test_db;
         is $txn_manager, +Mock::Basic->txn_manager;
 
         done_testing;
+        unlink $db;
     } else {
         my $txn = Mock::Basic->txn_scope;
 
@@ -44,5 +45,4 @@ Mock::Basic->setup_test_db;
         $txn->rollback;
     }
 
-unlink $db;
 


### PR DESCRIPTION
done_testing の前に dbファイルが削除されているため、テストが失敗しています。